### PR TITLE
Add multi-inbox support to backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Access the dashboard at `http://localhost:8080`
 ## Features
 
 - 📧 **IMAP Integration** - Automatically fetches DMARC reports from your email inbox
+- 📬 **Multi-Inbox Support** - Fetch from multiple IMAP accounts concurrently
 - 🔍 **RFC 7489 Compliant** - Fully compliant with DMARC aggregate report standards
 - 📊 **Beautiful Dashboard** - Modern Vue.js 3 SPA with real-time statistics
 - 🗄️ **SQLite Storage** - Lightweight embedded database, no external dependencies
@@ -124,6 +125,61 @@ The compiled binary will be at `./bin/parse-dmarc`.
   }
 }
 ```
+
+### Multi-Inbox Support
+
+Parse DMARC supports fetching from multiple IMAP inboxes concurrently. This is useful when you want to aggregate DMARC reports from multiple email accounts into a single dashboard.
+
+**Using configuration file:**
+
+Instead of using the single `imap` field, use the `imap_configs` array:
+
+```json
+{
+  "imap_configs": [
+    {
+      "host": "imap.gmail.com",
+      "port": 993,
+      "username": "account1@gmail.com",
+      "password": "your-app-password-1",
+      "mailbox": "INBOX",
+      "use_tls": true
+    },
+    {
+      "host": "imap.gmail.com",
+      "port": 993,
+      "username": "account2@gmail.com",
+      "password": "your-app-password-2",
+      "mailbox": "INBOX",
+      "use_tls": true
+    }
+  ],
+  "database": {
+    "path": "~/.parse-dmarc/db.sqlite"
+  },
+  "server": {
+    "port": 8080,
+    "host": "0.0.0.0"
+  }
+}
+```
+
+See `config.multi-inbox.example.json` for a complete example.
+
+**Using environment variable:**
+
+You can also configure multiple inboxes via the `IMAP_CONFIGS` environment variable with a JSON array:
+
+```bash
+export IMAP_CONFIGS='[{"host":"imap.gmail.com","port":993,"username":"account1@gmail.com","password":"pass1","mailbox":"INBOX","use_tls":true},{"host":"imap.gmail.com","port":993,"username":"account2@gmail.com","password":"pass2","mailbox":"INBOX","use_tls":true}]'
+```
+
+**Features:**
+- Concurrent fetching from all configured inboxes
+- Automatic deduplication of reports across inboxes
+- Individual error handling per inbox (one failing inbox doesn't stop others)
+- Progress logging shows which inbox is being processed
+- Backward compatible with single inbox configuration
 
 ### Running
 

--- a/config.multi-inbox.example.json
+++ b/config.multi-inbox.example.json
@@ -1,0 +1,35 @@
+{
+  "database": {
+    "path": "~/.parse-dmarc/db.sqlite"
+  },
+  "imap_configs": [
+    {
+      "host": "imap.gmail.com",
+      "mailbox": "INBOX",
+      "password": "your-app-password-1",
+      "port": 993,
+      "use_tls": true,
+      "username": "account1@gmail.com"
+    },
+    {
+      "host": "imap.gmail.com",
+      "mailbox": "INBOX",
+      "password": "your-app-password-2",
+      "port": 993,
+      "use_tls": true,
+      "username": "account2@gmail.com"
+    },
+    {
+      "host": "imap.example.com",
+      "mailbox": "DMARC",
+      "password": "your-password-3",
+      "port": 993,
+      "use_tls": true,
+      "username": "account3@example.com"
+    }
+  ],
+  "server": {
+    "host": "0.0.0.0",
+    "port": 8080
+  }
+}


### PR DESCRIPTION
This commit implements support for fetching DMARC reports from multiple IMAP inboxes concurrently while maintaining full backward compatibility with single inbox configurations.

Key changes:

Backend (internal/config/config.go):
- Add IMAPConfigs []IMAPConfig field to support multiple inboxes
- Add GetIMAPConfigs() method to normalize single/multi config access
- Support IMAP_CONFIGS environment variable for JSON array of configs
- Fix env.Parse bug that was overwriting array values with envDefaults
- Apply defaults correctly to both single and multiple configs
- Maintain backward compatibility with existing single IMAP config

Fetching logic (cmd/parse-dmarc/main.go):
- Update fetchReports() to iterate through all IMAP configs
- Use goroutines and sync.WaitGroup for concurrent fetching
- Add per-inbox error handling (one failing inbox doesn't stop others)
- Aggregate total processed reports across all inboxes
- Enhanced logging with inbox progress indicators [Inbox 1/3]
- Return error only if all inboxes fail

Documentation:
- Add comprehensive multi-inbox section to README.md
- Include configuration file and environment variable examples
- Add feature description and benefits
- Create config.multi-inbox.example.json with 3-inbox example
- Update features list to highlight multi-inbox support

Benefits:
- Concurrent fetching improves performance for multiple inboxes
- Automatic deduplication via existing report_id constraint
- No UI changes required - completely transparent to frontend
- Backward compatible - single inbox configs work unchanged
- Flexible configuration via JSON file or environment variables

Testing:
- Verified single inbox backward compatibility
- Verified multi-inbox configuration loading
- Tested mailbox name preservation (no envDefault overwrites)
- Confirmed successful build with no errors