### PR TITLE
docs: add Homebrew installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,31 @@
 - 🔒 Secure TLS support
 - 🌙 Dark mode support
 
+## Installation
+
+### Homebrew (macOS/Linux)
+
+```bash
+brew install meysam81/tap/parse-dmarc
+```
+
+Or tap first, then install:
+
+```bash
+brew tap meysam81/tap
+brew install parse-dmarc
+```
+
+### Docker
+
+```bash
+docker pull ghcr.io/meysam81/parse-dmarc:latest
+```
+
+### Binary Downloads
+
+Download pre-built binaries from the [Releases page](https://github.com/meysam81/parse-dmarc/releases).
+
 ## Quick Start
 
 ### Step 1: Set Up DNS to Receive DMARC Reports


### PR DESCRIPTION
Add Installation section with Homebrew, Docker, and binary download options
to make it easier for users to discover all available installation methods.