### PR TITLE
Switch env and json config parsing order

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,10 @@ func Load(path string) (*Config, error) {
 	var cfg Config
 	var err error
 
+	if err := env.Parse(&cfg); err != nil {
+		return nil, err
+	}
+
 	if _, err := os.Stat(path); err == nil {
 		data, err := os.ReadFile(path)
 		if err != nil {
@@ -84,10 +88,6 @@ func Load(path string) (*Config, error) {
 		if err := json.Unmarshal(data, &cfg); err != nil {
 			return nil, err
 		}
-	}
-
-	if err := env.Parse(&cfg); err != nil {
-		return nil, err
 	}
 
 	if cfg.IMAP.Port == 0 {


### PR DESCRIPTION
The value of "envDefault" property was overwriting any value set in config.json file. By switching the config parsing order, the "envDefault" doesn't interfere with using config.json