### PR TITLE
Modify BodySectionName to use Peek option

### DIFF
--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -122,7 +122,7 @@ func (c *Client) FetchDMARCReports() (*FetchResult, error) {
 	messages := make(chan *imap.Message, 10)
 	done := make(chan error, 1)
 
-	section := &imap.BodySectionName{}
+	section := &imap.BodySectionName{Peek: !c.config.MarkAsSeen}
 	items := []imap.FetchItem{section.FetchItem(), imap.FetchEnvelope, imap.FetchFlags}
 
 	go func() {


### PR DESCRIPTION
When fetching message bodies, the IMAP protocol (RFC 3501) automatically sets the \Seen flag server-side when using BODY[], regardless of any explicit MarkAsSeen call.
Using BODY.PEEK[] instead silently fetches the body without altering any flags, which is the correct behavior when MarkAsSeen is false.