### PR TITLE
feat: GitHub OAuth authentication for the dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,49 @@ go test -v ./internal/parser/...
 | `--mcp-oauth-introspection-endpoint` | `PARSE_DMARC_MCP_OAUTH_INTROSPECTION_ENDPOINT` | Token introspection endpoint URL                      |
 | `--mcp-oauth-resource-name`          | `PARSE_DMARC_MCP_OAUTH_RESOURCE_NAME`          | Human-readable name for MCP server metadata           |
 | `--mcp-oauth-insecure`               | `PARSE_DMARC_MCP_OAUTH_INSECURE`               | Skip TLS certificate verification (dev only)          |
+| `--gen-session-secret`               | `PARSE_DMARC_GEN_SESSION_SECRET`               | Print a base64-encoded 32-byte session secret and exit |
+
+## Dashboard Authentication (GitHub OAuth)
+
+The dashboard runs unauthenticated by default. To require login, add an
+`auth` block to `config.json`:
+
+```json
+"auth": {
+  "enabled": true,
+  "client_id": "Iv1.xxxxxxxxxxxxxxxx",
+  "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+  "redirect_url": "https://dmarc.example.com/auth/callback",
+  "session_secret": "<output of --gen-session-secret>",
+  "allowed_emails": ["seb@example.com"],
+  "allowed_users":  ["sebykrueger"],
+  "session_ttl_days": 7
+}
+```
+
+Setup steps:
+
+1. Generate a session secret: `./parse-dmarc --gen-session-secret`. Paste
+   into `auth.session_secret`.
+2. Create a GitHub OAuth App at <https://github.com/settings/developers> →
+   **New OAuth App**:
+   - **Homepage URL**: your dashboard URL (e.g., `https://dmarc.example.com`)
+   - **Authorization callback URL**: must exactly match `auth.redirect_url`
+3. Copy the Client ID and Client secret into `config.json`.
+4. Configure `allowed_emails` and/or `allowed_users` — at least one entry is
+   required (otherwise no one can log in).
+5. Restart the daemon. Visiting any dashboard URL now redirects to GitHub.
+
+Behavior notes:
+
+- `/api/*` returns `401 application/json` with `{"login_url":"/auth/login"}`
+  for programmatic clients.
+- `/metrics` and `/healthz` are intentionally **not** auth-gated so
+  Prometheus scrapers and uptime checks still work.
+- Sessions are stateless: an HMAC-signed cookie carries `sub`, `email`,
+  `iat`, `exp`. No server-side session store.
+- Session TTL defaults to 7 days; configurable via `session_ttl_days`.
+- Cookies use `Secure` automatically when `redirect_url` is `https://`.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Deploy Parse DMARC to your favorite cloud provider with one click:
 - 📦 Single binary - no databases to install, no complex setup
 - 🚀 Tiny 14MB Docker image
 - 🔒 Secure TLS support
+- 🔐 Optional GitHub OAuth login for the dashboard ([details](#dashboard-authentication))
 - 🌙 Dark mode support
 
 ## Installation
@@ -153,6 +154,117 @@ This helps you:
 - Verify your legitimate email services are properly configured
 - Detect unauthorized use of your domain
 - Gradually move from monitoring (`p=none`) to enforcement (`p=quarantine` or `p=reject`)
+
+## Dashboard Authentication
+
+The dashboard runs unauthenticated by default — fine for `localhost`, but if
+you expose it to the internet you'll want login. Parse DMARC ships with
+**GitHub OAuth** out of the box.
+
+### Step 1 — Create a GitHub OAuth App
+
+Go to <https://github.com/settings/developers> → **OAuth Apps** → **New OAuth App**:
+
+| Field | Value |
+| --- | --- |
+| **Application name** | `dmarcguard` (anything — only you see it) |
+| **Homepage URL** | Your dashboard URL, e.g. `https://dmarc.example.com` (or `http://localhost:8080` for local testing) |
+| **Authorization callback URL** | Same as above with `/auth/callback` appended, e.g. `https://dmarc.example.com/auth/callback` |
+| **Enable Device Flow** | ❌ Leave unchecked |
+
+Click **Register application**. On the next screen:
+
+1. Copy the **Client ID** (visible immediately).
+2. Click **Generate a new client secret** → copy the secret (only shown once).
+
+> The callback URL above must match `auth.redirect_url` in your config **exactly** — including scheme (`http`/`https`), host, port, and path. A mismatch produces GitHub's `redirect_uri_mismatch` error.
+
+### Step 2 — Generate a session secret
+
+```bash
+./parse-dmarc --gen-session-secret
+# nX2Fc0PbLjYOvGPrO3MsZ6o+To2MHi3hJp48czUnH+U=
+```
+
+Or in Docker:
+
+```bash
+docker compose run --rm parse-dmarc --gen-session-secret
+```
+
+This is a 32-byte random key used to sign session cookies (HMAC-SHA256). Treat it like any other secret — anyone who has it can mint valid sessions for any allowlisted user.
+
+### Step 3 — Add the `auth` block to `config.json`
+
+```json
+"auth": {
+  "enabled": true,
+  "client_id": "Iv1.xxxxxxxxxxxxxxxx",
+  "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+  "redirect_url": "https://dmarc.example.com/auth/callback",
+  "session_secret": "nX2Fc0PbLjYOvGPrO3MsZ6o+To2MHi3hJp48czUnH+U=",
+  "allowed_users": ["sebykrueger"],
+  "allowed_emails": ["seb@example.com"],
+  "session_ttl_days": 7
+}
+```
+
+**Allowlist semantics:**
+
+- `allowed_users` matches the GitHub username (e.g. `sebykrueger`).
+- `allowed_emails` matches the verified primary email on the GitHub account.
+- A user is granted access if **either** list contains their identity (OR, not AND). Case-insensitive on both sides.
+- At least one entry across the two lists is required — the daemon refuses to start with `auth.enabled=true` and an empty allowlist (otherwise nobody could log in).
+
+**Optional fields:**
+
+- `session_ttl_days` — how long a login lasts. Default: 7 days.
+- The `Secure` cookie flag is set automatically when `redirect_url` starts with `https://`.
+
+### Step 4 — Restart the daemon
+
+```bash
+docker compose restart parse-dmarc
+```
+
+You should see this log line confirming auth is on:
+
+```
+INF dashboard authentication enabled (github) allowed_emails=1 allowed_users=1
+```
+
+### What changes after auth is enabled
+
+| Path | Behavior |
+| --- | --- |
+| `/` and the dashboard SPA | 303 redirect to `/auth/login` if no valid session cookie |
+| `/api/*` | `401 application/json` with `{"error":"unauthorized","login_url":"/auth/login"}` for programmatic callers |
+| `/auth/login` | Redirects to GitHub OAuth |
+| `/auth/callback` | Receives the code, validates state (CSRF), checks the allowlist, sets the session cookie |
+| `/auth/logout` | Clears the session cookie and redirects to login |
+| `/metrics` | **Still open** — Prometheus scrapers don't need to authenticate |
+
+### Environment variable equivalents
+
+Every field has an env var, useful for Docker secrets / Vault / k8s secrets:
+
+```bash
+AUTH_ENABLED=true
+AUTH_CLIENT_ID=Iv1.xxxxxxxxxxxxxxxx
+AUTH_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+AUTH_REDIRECT_URL=https://dmarc.example.com/auth/callback
+AUTH_SESSION_SECRET=nX2Fc0PbLjYOvGPrO3MsZ6o+To2MHi3hJp48czUnH+U=
+AUTH_ALLOWED_USERS=sebykrueger,alice
+AUTH_ALLOWED_EMAILS=seb@example.com
+AUTH_SESSION_TTL_DAYS=7
+```
+
+### Common gotchas
+
+- **`redirect_uri_mismatch` from GitHub** — the OAuth App's callback URL doesn't match `auth.redirect_url` to the byte. Trailing slash counts.
+- **403 "not authorized"** after a successful GitHub login — your username/email isn't in the allowlist. Either add it, or switch to a different GitHub account.
+- **Removing someone from the allowlist doesn't kick them out immediately** — sessions are cookie-based and last `session_ttl_days`. To force-evict, rotate `auth.session_secret` (invalidates all sessions).
+- **Cookies aren't `Secure` on `http://`** — fine for local, dangerous in production. Always use HTTPS for any internet-facing deployment (a reverse proxy with Caddy / Traefik / nginx-acme handles this in one line).
 
 ## Configuration Options
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/goccy/go-json"
 	"github.com/rs/zerolog"
 
+	"github.com/meysam81/parse-dmarc/internal/auth"
 	"github.com/meysam81/parse-dmarc/internal/metrics"
 	"github.com/meysam81/parse-dmarc/internal/storage"
 )
@@ -21,10 +22,12 @@ var distFS embed.FS
 
 // Server represents the API server
 type Server struct {
-	storage *storage.Storage
-	metrics *metrics.Metrics
-	log     *zerolog.Logger
-	addr    string
+	storage      *storage.Storage
+	metrics      *metrics.Metrics
+	log          *zerolog.Logger
+	addr         string
+	authHandlers *auth.Handlers
+	authSigner   *auth.SessionSigner
 }
 
 // NewServer creates a new API server
@@ -37,29 +40,49 @@ func NewServer(store *storage.Storage, host string, port int, m *metrics.Metrics
 	}
 }
 
+// WithAuth enables dashboard authentication. When called, /api/* and / are
+// gated behind a valid session cookie and /auth/* handlers are mounted.
+// Pass nil to disable auth (default).
+func (s *Server) WithAuth(handlers *auth.Handlers, signer *auth.SessionSigner) *Server {
+	s.authHandlers = handlers
+	s.authSigner = signer
+	return s
+}
+
 // Start starts the HTTP server
 func (s *Server) Start(ctx context.Context) error {
 	mux := http.NewServeMux()
 
-	// API routes
-	mux.HandleFunc("/api/reports", s.handleReports)
-	mux.HandleFunc("/api/reports/", s.handleReportDetail)
-	mux.HandleFunc("/api/statistics", s.handleStatistics)
-	mux.HandleFunc("/api/top-sources", s.handleTopSources)
+	// Build the protected portion of the router (API + frontend) on its own
+	// mux so the auth middleware can wrap it cleanly. /metrics and /auth/*
+	// stay on the outer mux — Prometheus needs unauthenticated scrapes, and
+	// /auth/* obviously can't sit behind the auth gate.
+	protectedMux := http.NewServeMux()
 
-	// Prometheus metrics endpoint
+	// API routes
+	protectedMux.HandleFunc("/api/reports", s.handleReports)
+	protectedMux.HandleFunc("/api/reports/", s.handleReportDetail)
+	protectedMux.HandleFunc("/api/statistics", s.handleStatistics)
+	protectedMux.HandleFunc("/api/top-sources", s.handleTopSources)
+
+	// Prometheus metrics endpoint (always unauthenticated for scrapers)
 	if s.metrics != nil {
 		mux.Handle("/metrics", s.metrics.Handler())
 	}
 
-	// Serve frontend
+	// Auth handlers
+	if s.authHandlers != nil {
+		s.authHandlers.Mount(mux)
+	}
+
+	// Serve frontend (mounted on protectedMux so the dashboard SPA is gated)
 	// Try to serve embedded files, fallback to nothing if not embedded
 	distFiles, err := fs.Sub(distFS, "dist")
 	if err == nil {
-		mux.Handle("/", http.FileServer(http.FS(distFiles)))
+		protectedMux.Handle("/", http.FileServer(http.FS(distFiles)))
 	} else {
 		// If dist folder is not embedded, serve a simple message
-		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		protectedMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/" {
 				w.Header().Set("Content-Type", "text/html")
 				_, _ = fmt.Fprintf(w, `
@@ -83,6 +106,13 @@ func (s *Server) Start(ctx context.Context) error {
 			}
 		})
 	}
+
+	// Mount protected routes (gated by auth middleware when enabled).
+	var protected http.Handler = protectedMux
+	if s.authSigner != nil {
+		protected = auth.Middleware(s.authSigner, protected)
+	}
+	mux.Handle("/", protected)
 
 	// Build handler chain: CORS -> Metrics -> Routes
 	var handler http.Handler = mux

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -64,6 +64,7 @@ func (s *Server) Start(ctx context.Context) error {
 	protectedMux.HandleFunc("/api/reports/", s.handleReportDetail)
 	protectedMux.HandleFunc("/api/statistics", s.handleStatistics)
 	protectedMux.HandleFunc("/api/top-sources", s.handleTopSources)
+	protectedMux.HandleFunc("/api/auth/me", s.handleAuthMe)
 
 	// Prometheus metrics endpoint (always unauthenticated for scrapers)
 	if s.metrics != nil {
@@ -261,6 +262,29 @@ func (s *Server) writeJSON(w http.ResponseWriter, data interface{}) {
 	if err := json.NewEncoder(w).Encode(data); err != nil {
 		s.log.Error().Err(err).Msg("failed to encode JSON")
 	}
+}
+
+// handleAuthMe returns the current authenticated user's information
+func (s *Server) handleAuthMe(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract user info from context (set by auth middleware)
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized","login_url":"/auth/login"}`))
+		return
+	}
+
+	s.writeJSON(w, map[string]string{
+		"login":      user.Login,
+		"email":      user.Email,
+		"logout_url": "/auth/logout",
+	})
 }
 
 // RefreshMetrics updates all Prometheus metrics from current database state

--- a/internal/auth/github.go
+++ b/internal/auth/github.go
@@ -1,0 +1,188 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/goccy/go-json"
+)
+
+// GitHub OAuth and API endpoints.
+const (
+	githubAuthURL   = "https://github.com/login/oauth/authorize"
+	githubTokenURL  = "https://github.com/login/oauth/access_token"
+	githubUserURL   = "https://api.github.com/user"
+	githubEmailsURL = "https://api.github.com/user/emails"
+	githubScope     = "read:user user:email"
+	githubUserAgent = "dmarcguard"
+)
+
+// Identity is what the OAuth callback hands off to the allowlist + signer.
+type Identity struct {
+	Login string // GitHub username
+	Email string // verified primary email
+}
+
+// GitHubClient wraps the OAuth dance and the user/emails API calls.
+// Construct via NewGitHubClient.
+type GitHubClient struct {
+	clientID     string
+	clientSecret string
+	redirectURL  string
+	httpClient   *http.Client
+}
+
+// NewGitHubClient returns a client. http.DefaultClient is used when h is nil.
+func NewGitHubClient(clientID, clientSecret, redirectURL string, h *http.Client) *GitHubClient {
+	if h == nil {
+		h = http.DefaultClient
+	}
+	return &GitHubClient{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		redirectURL:  redirectURL,
+		httpClient:   h,
+	}
+}
+
+// AuthCodeURL builds the GitHub authorization URL for the given state.
+func (g *GitHubClient) AuthCodeURL(state string) string {
+	q := url.Values{}
+	q.Set("client_id", g.clientID)
+	q.Set("redirect_uri", g.redirectURL)
+	q.Set("scope", githubScope)
+	q.Set("state", state)
+	q.Set("allow_signup", "false")
+	return githubAuthURL + "?" + q.Encode()
+}
+
+// Exchange swaps an authorization code for an access token, then fetches the
+// authenticated user's verified primary email and login. The returned Identity
+// is what the allowlist is checked against.
+func (g *GitHubClient) Exchange(ctx context.Context, code string) (*Identity, error) {
+	tok, err := g.fetchToken(ctx, code)
+	if err != nil {
+		return nil, fmt.Errorf("exchange code: %w", err)
+	}
+
+	login, err := g.fetchLogin(ctx, tok)
+	if err != nil {
+		return nil, fmt.Errorf("fetch user: %w", err)
+	}
+
+	email, err := g.fetchPrimaryVerifiedEmail(ctx, tok)
+	if err != nil {
+		return nil, fmt.Errorf("fetch email: %w", err)
+	}
+
+	return &Identity{Login: login, Email: email}, nil
+}
+
+func (g *GitHubClient) fetchToken(ctx context.Context, code string) (string, error) {
+	body := url.Values{}
+	body.Set("client_id", g.clientID)
+	body.Set("client_secret", g.clientSecret)
+	body.Set("code", code)
+	body.Set("redirect_uri", g.redirectURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, githubTokenURL, strings.NewReader(body.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", githubUserAgent)
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github token endpoint returned %d: %s", resp.StatusCode, string(raw))
+	}
+
+	var tokResp struct {
+		AccessToken string `json:"access_token"`
+		Error       string `json:"error"`
+		ErrorDesc   string `json:"error_description"`
+	}
+	if err := json.Unmarshal(raw, &tokResp); err != nil {
+		return "", fmt.Errorf("parse token response: %w", err)
+	}
+	if tokResp.Error != "" {
+		return "", fmt.Errorf("github oauth error %q: %s", tokResp.Error, tokResp.ErrorDesc)
+	}
+	if tokResp.AccessToken == "" {
+		return "", errors.New("github returned empty access token")
+	}
+	return tokResp.AccessToken, nil
+}
+
+func (g *GitHubClient) fetchLogin(ctx context.Context, token string) (string, error) {
+	var u struct {
+		Login string `json:"login"`
+	}
+	if err := g.getJSON(ctx, githubUserURL, token, &u); err != nil {
+		return "", err
+	}
+	if u.Login == "" {
+		return "", errors.New("github user response missing login")
+	}
+	return u.Login, nil
+}
+
+func (g *GitHubClient) fetchPrimaryVerifiedEmail(ctx context.Context, token string) (string, error) {
+	var emails []struct {
+		Email    string `json:"email"`
+		Primary  bool   `json:"primary"`
+		Verified bool   `json:"verified"`
+	}
+	if err := g.getJSON(ctx, githubEmailsURL, token, &emails); err != nil {
+		return "", err
+	}
+	for _, e := range emails {
+		if e.Primary && e.Verified {
+			return e.Email, nil
+		}
+	}
+	// Fallback: any verified email.
+	for _, e := range emails {
+		if e.Verified {
+			return e.Email, nil
+		}
+	}
+	return "", errors.New("no verified email on github account")
+}
+
+func (g *GitHubClient) getJSON(ctx context.Context, urlStr, token string, into interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", githubUserAgent)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("github api %s returned %d: %s", urlStr, resp.StatusCode, string(raw))
+	}
+	return json.NewDecoder(resp.Body).Decode(into)
+}

--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -1,0 +1,147 @@
+package auth
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// Handlers carries the dependencies for the /auth/* HTTP handlers.
+type Handlers struct {
+	GitHub    *GitHubClient
+	Signer    *SessionSigner
+	Allowlist *Allowlist
+	Log       *zerolog.Logger
+	// Secure controls whether session/state cookies set the Secure flag.
+	// Disabled when the redirect URL is http:// (typically local dev).
+	Secure bool
+}
+
+// NewHandlers constructs Handlers and infers the Secure flag from the
+// redirect URL scheme.
+func NewHandlers(github *GitHubClient, signer *SessionSigner, allowlist *Allowlist, redirectURL string, log *zerolog.Logger) *Handlers {
+	return &Handlers{
+		GitHub:    github,
+		Signer:    signer,
+		Allowlist: allowlist,
+		Log:       log,
+		Secure:    strings.HasPrefix(redirectURL, "https://"),
+	}
+}
+
+// Mount attaches /auth/login, /auth/callback, and /auth/logout to mux.
+func (h *Handlers) Mount(mux *http.ServeMux) {
+	mux.HandleFunc("/auth/login", h.Login)
+	mux.HandleFunc("/auth/callback", h.Callback)
+	mux.HandleFunc("/auth/logout", h.Logout)
+}
+
+// Login generates a fresh state token, sets it as a short-lived cookie, and
+// redirects to GitHub's authorization endpoint.
+func (h *Handlers) Login(w http.ResponseWriter, r *http.Request) {
+	state, err := h.Signer.SignState(time.Now())
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     StateCookieName,
+		Value:    state,
+		Path:     "/auth/callback",
+		MaxAge:   600,
+		HttpOnly: true,
+		Secure:   h.Secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+	http.Redirect(w, r, h.GitHub.AuthCodeURL(state), http.StatusSeeOther)
+}
+
+// Callback validates the OAuth state, exchanges the code for an identity,
+// checks the allowlist, signs a session cookie, and redirects to /.
+func (h *Handlers) Callback(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	if e := q.Get("error"); e != "" {
+		h.Log.Warn().Str("error", e).Str("desc", q.Get("error_description")).Msg("github oauth error")
+		http.Error(w, "GitHub authorization failed: "+e, http.StatusBadRequest)
+		return
+	}
+	code := q.Get("code")
+	state := q.Get("state")
+	if code == "" || state == "" {
+		http.Error(w, "missing code or state", http.StatusBadRequest)
+		return
+	}
+
+	stateCookie, err := r.Cookie(StateCookieName)
+	if err != nil || stateCookie.Value != state {
+		http.Error(w, "invalid OAuth state (possible CSRF or stale link)", http.StatusBadRequest)
+		return
+	}
+	if err := h.Signer.VerifyState(state, time.Now()); err != nil {
+		http.Error(w, "OAuth state expired or tampered", http.StatusBadRequest)
+		return
+	}
+
+	// Clear the state cookie immediately — single-use.
+	http.SetCookie(w, &http.Cookie{
+		Name:     StateCookieName,
+		Value:    "",
+		Path:     "/auth/callback",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   h.Secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	id, err := h.GitHub.Exchange(r.Context(), code)
+	if err != nil {
+		h.Log.Warn().Err(err).Msg("github exchange failed")
+		http.Error(w, "GitHub authentication failed", http.StatusBadGateway)
+		return
+	}
+
+	if !h.Allowlist.Allows(id) {
+		h.Log.Warn().Str("login", id.Login).Str("email", id.Email).Msg("login denied: not on allowlist")
+		http.Error(w, "Account "+id.Login+" ("+id.Email+") is not authorized to access this dashboard.", http.StatusForbidden)
+		return
+	}
+
+	cookieValue, err := h.Signer.Sign(id.Login, id.Email, time.Now())
+	if err != nil {
+		h.Log.Error().Err(err).Msg("session sign failed")
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     CookieName,
+		Value:    cookieValue,
+		Path:     "/",
+		MaxAge:   int(h.Signer.TTL().Seconds()),
+		HttpOnly: true,
+		Secure:   h.Secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	h.Log.Info().Str("login", id.Login).Str("email", id.Email).Msg("login succeeded")
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+// Logout clears the session cookie and redirects to /auth/login.
+// Accepts both POST (for forms) and GET (for "logout" links) — the latter
+// is fine because the cookie is HttpOnly and SameSite=Lax, so cross-site
+// triggering still requires user navigation.
+func (h *Handlers) Logout(w http.ResponseWriter, r *http.Request) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     CookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   h.Secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+	http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+}

--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -31,11 +31,12 @@ func NewHandlers(github *GitHubClient, signer *SessionSigner, allowlist *Allowli
 	}
 }
 
-// Mount attaches /auth/login, /auth/callback, and /auth/logout to mux.
+// Mount attaches the /auth/* handlers to mux.
 func (h *Handlers) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("/auth/login", h.Login)
 	mux.HandleFunc("/auth/callback", h.Callback)
 	mux.HandleFunc("/auth/logout", h.Logout)
+	mux.HandleFunc("/auth/logged-out", h.LoggedOut)
 }
 
 // Login generates a fresh state token, sets it as a short-lived cookie, and
@@ -129,10 +130,16 @@ func (h *Handlers) Callback(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }
 
-// Logout clears the session cookie and redirects to /auth/login.
-// Accepts both POST (for forms) and GET (for "logout" links) — the latter
-// is fine because the cookie is HttpOnly and SameSite=Lax, so cross-site
-// triggering still requires user navigation.
+// Logout clears the session cookie and redirects to a dedicated "signed out"
+// page. We deliberately do NOT redirect to /auth/login here — that would
+// immediately bounce the user back through GitHub, and (because GitHub
+// remembers the prior consent) they'd be silently re-authenticated and end
+// up exactly where they started. The dedicated landing page makes the user
+// click an explicit "Sign in" link to come back.
+//
+// Accepts both POST (for forms) and GET (for plain "logout" links) — the
+// cookie is HttpOnly and SameSite=Lax, so cross-site triggering still
+// requires user navigation.
 func (h *Handlers) Logout(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     CookieName,
@@ -143,5 +150,38 @@ func (h *Handlers) Logout(w http.ResponseWriter, r *http.Request) {
 		Secure:   h.Secure,
 		SameSite: http.SameSiteLaxMode,
 	})
-	http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+	http.Redirect(w, r, "/auth/logged-out", http.StatusSeeOther)
+}
+
+// LoggedOut is the post-logout landing page. Plain HTML (no Vue) so the
+// browser can render it without re-authenticating against the gated SPA.
+func (h *Handlers) LoggedOut(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	_, _ = w.Write([]byte(`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Signed out — dmarcguard</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; max-width: 28rem; margin: 6rem auto; padding: 2rem; line-height: 1.6; }
+  h1 { font-size: 1.5rem; margin: 0 0 0.5rem; }
+  p { opacity: 0.75; margin: 0 0 1.5rem; }
+  a.btn { display: inline-block; padding: 0.625rem 1.25rem; background: #1f2937; color: #fff; text-decoration: none; border-radius: 0.375rem; font-weight: 500; }
+  a.btn:hover { background: #111827; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #0f172a; color: #e2e8f0; }
+    a.btn { background: #e2e8f0; color: #0f172a; }
+    a.btn:hover { background: #fff; }
+  }
+</style>
+</head>
+<body>
+  <h1>Signed out</h1>
+  <p>You've been signed out of dmarcguard. Your session cookie has been cleared.</p>
+  <p><a class="btn" href="/auth/login">Sign in again</a></p>
+</body>
+</html>`))
 }

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,10 +1,16 @@
 package auth
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"time"
 )
+
+// contextKey is a private type for context keys to avoid collisions
+type contextKey string
+
+const userContextKey contextKey = "user"
 
 // Allowlist holds the set of GitHub usernames and verified emails authorized
 // to access the dashboard. Matching is case-insensitive on both sides.
@@ -43,6 +49,15 @@ func (a *Allowlist) Allows(id *Identity) bool {
 	return false
 }
 
+// UserFromContext extracts the Identity from the request context.
+// Returns nil if no identity is present (e.g., unauthenticated request).
+func UserFromContext(ctx context.Context) *Identity {
+	if id, ok := ctx.Value(userContextKey).(*Identity); ok {
+		return id
+	}
+	return nil
+}
+
 // Middleware wraps next with a session check. Unauthenticated requests are
 // either redirected to /auth/login (for HTML/dashboard requests) or get a
 // 401 JSON response (for /api/* requests). The split avoids breaking
@@ -54,11 +69,16 @@ func Middleware(signer *SessionSigner, next http.Handler) http.Handler {
 			deny(w, r)
 			return
 		}
-		if _, err := signer.Verify(cookie.Value, time.Now()); err != nil {
+		session, err := signer.Verify(cookie.Value, time.Now())
+		if err != nil {
 			deny(w, r)
 			return
 		}
-		next.ServeHTTP(w, r)
+		// Reconstruct the Identity from the session (Subject was set to the
+		// GitHub login at sign-time). UserFromContext expects *Identity.
+		identity := &Identity{Login: session.Subject, Email: session.Email}
+		ctx := context.WithValue(r.Context(), userContextKey, identity)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,0 +1,73 @@
+package auth
+
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Allowlist holds the set of GitHub usernames and verified emails authorized
+// to access the dashboard. Matching is case-insensitive on both sides.
+type Allowlist struct {
+	emails map[string]struct{}
+	users  map[string]struct{}
+}
+
+// NewAllowlist normalizes and indexes the configured allowlist entries.
+func NewAllowlist(emails, users []string) *Allowlist {
+	a := &Allowlist{
+		emails: make(map[string]struct{}, len(emails)),
+		users:  make(map[string]struct{}, len(users)),
+	}
+	for _, e := range emails {
+		if e = strings.TrimSpace(strings.ToLower(e)); e != "" {
+			a.emails[e] = struct{}{}
+		}
+	}
+	for _, u := range users {
+		if u = strings.TrimSpace(strings.ToLower(u)); u != "" {
+			a.users[u] = struct{}{}
+		}
+	}
+	return a
+}
+
+// Allows returns true if the identity matches at least one allowlist entry.
+func (a *Allowlist) Allows(id *Identity) bool {
+	if _, ok := a.emails[strings.ToLower(id.Email)]; ok {
+		return true
+	}
+	if _, ok := a.users[strings.ToLower(id.Login)]; ok {
+		return true
+	}
+	return false
+}
+
+// Middleware wraps next with a session check. Unauthenticated requests are
+// either redirected to /auth/login (for HTML/dashboard requests) or get a
+// 401 JSON response (for /api/* requests). The split avoids breaking
+// programmatic API consumers that should see a 401 rather than a 302.
+func Middleware(signer *SessionSigner, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cookie, err := r.Cookie(CookieName)
+		if err != nil {
+			deny(w, r)
+			return
+		}
+		if _, err := signer.Verify(cookie.Value, time.Now()); err != nil {
+			deny(w, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func deny(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, "/api/") {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized","login_url":"/auth/login"}`))
+		return
+	}
+	http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,0 +1,86 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestAllowlist_EmailMatch(t *testing.T) {
+	a := NewAllowlist([]string{"Alice@Example.com"}, nil)
+	if !a.Allows(&Identity{Login: "alice", Email: "alice@example.com"}) {
+		t.Fatal("email should match case-insensitively")
+	}
+	if a.Allows(&Identity{Login: "bob", Email: "bob@example.com"}) {
+		t.Fatal("non-allowed email should be rejected")
+	}
+}
+
+func TestAllowlist_LoginMatch(t *testing.T) {
+	a := NewAllowlist(nil, []string{"sebykrueger"})
+	if !a.Allows(&Identity{Login: "SebyKrueger", Email: "x@example.com"}) {
+		t.Fatal("login should match case-insensitively")
+	}
+}
+
+func TestAllowlist_EmptyDeniesAll(t *testing.T) {
+	a := NewAllowlist(nil, nil)
+	if a.Allows(&Identity{Login: "anyone", Email: "anyone@example.com"}) {
+		t.Fatal("empty allowlist must deny everyone")
+	}
+}
+
+func TestMiddleware_ProtectedRedirectsBrowser(t *testing.T) {
+	signer := newSigner(t)
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := Middleware(signer, next)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	mw.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", rr.Code)
+	}
+	if loc := rr.Header().Get("Location"); loc != "/auth/login" {
+		t.Fatalf("expected Location=/auth/login, got %q", loc)
+	}
+}
+
+func TestMiddleware_ApiReturns401Json(t *testing.T) {
+	signer := newSigner(t)
+	mw := Middleware(signer, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/statistics", nil)
+	rr := httptest.NewRecorder()
+	mw.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected JSON, got %q", ct)
+	}
+}
+
+func TestMiddleware_ValidSessionPassesThrough(t *testing.T) {
+	signer := newSigner(t)
+	cookie, _ := signer.Sign("alice", "a@x.com", time.Now())
+
+	called := false
+	mw := Middleware(signer, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/statistics", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: cookie})
+	rr := httptest.NewRecorder()
+	mw.ServeHTTP(rr, req)
+
+	if !called {
+		t.Fatal("next handler should have been invoked for valid session")
+	}
+}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -84,3 +84,28 @@ func TestMiddleware_ValidSessionPassesThrough(t *testing.T) {
 		t.Fatal("next handler should have been invoked for valid session")
 	}
 }
+
+// Regression: UserFromContext must return a usable Identity for downstream
+// handlers (e.g. /api/auth/me). A previous bug stored *Session in the context
+// but UserFromContext type-asserted to *Identity, so it always returned nil
+// even on authenticated requests — which silently hid the logout button.
+func TestMiddleware_PopulatesUserContext(t *testing.T) {
+	signer := newSigner(t)
+	cookie, _ := signer.Sign("sebykrueger", "seb@example.com", time.Now())
+
+	var seen *Identity
+	mw := Middleware(signer, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = UserFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/me", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: cookie})
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if seen == nil {
+		t.Fatal("UserFromContext returned nil for an authenticated request")
+	}
+	if seen.Login != "sebykrueger" || seen.Email != "seb@example.com" {
+		t.Fatalf("identity mismatch: got %+v", seen)
+	}
+}

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -1,0 +1,189 @@
+// Package auth implements GitHub OAuth-backed authentication for the dashboard.
+//
+// Session model: a signed cookie carries a small payload (subject, issued_at,
+// expires_at). Signing uses HMAC-SHA256 with a server-side secret. There is no
+// server-side session store — the cookie itself is the session.
+//
+// Cookie format: base64url(payload-json) + "." + base64url(hmac-sha256(payload, secret))
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/goccy/go-json"
+)
+
+// CookieName is the HTTP cookie that carries the dashboard session.
+const CookieName = "dmarcguard_session"
+
+// StateCookieName is the short-lived cookie that carries the OAuth state token
+// used to defeat CSRF on the OAuth callback. It is deleted as soon as the
+// callback validates it.
+const StateCookieName = "dmarcguard_oauth_state"
+
+// DefaultSessionTTL is used when AuthConfig.SessionTTLDays is unset (0).
+const DefaultSessionTTL = 7 * 24 * time.Hour
+
+// Errors returned by session decode. Callers treat any of these as
+// "user is not authenticated" rather than distinguishing failure modes.
+var (
+	ErrSessionMissing   = errors.New("session cookie missing")
+	ErrSessionMalformed = errors.New("session cookie malformed")
+	ErrSessionBadSig    = errors.New("session cookie signature mismatch")
+	ErrSessionExpired   = errors.New("session expired")
+)
+
+// Session is what we store inside the cookie. It is intentionally tiny — just
+// enough to identify the user and enforce expiry. The allowlist check happens
+// at session-creation time (callback handler), so by the time a session
+// exists, the user is already authorized.
+type Session struct {
+	Subject   string `json:"sub"`   // GitHub username
+	Email     string `json:"email"` // verified primary email
+	IssuedAt  int64  `json:"iat"`
+	ExpiresAt int64  `json:"exp"`
+}
+
+// SessionSigner signs and verifies session cookies using HMAC-SHA256.
+// Construct via NewSessionSigner; key is the raw secret bytes (≥32 bytes).
+type SessionSigner struct {
+	key []byte
+	ttl time.Duration
+}
+
+// NewSessionSigner constructs a signer from a base64-encoded secret string and
+// a TTL. ttlDays<=0 selects DefaultSessionTTL.
+func NewSessionSigner(b64Secret string, ttlDays int) (*SessionSigner, error) {
+	key, err := base64.StdEncoding.DecodeString(b64Secret)
+	if err != nil {
+		// Fall back to raw bytes — let users paste a non-base64 secret if they want.
+		key = []byte(b64Secret)
+	}
+	if len(key) < 32 {
+		return nil, fmt.Errorf("session secret must be ≥32 bytes (got %d)", len(key))
+	}
+	ttl := DefaultSessionTTL
+	if ttlDays > 0 {
+		ttl = time.Duration(ttlDays) * 24 * time.Hour
+	}
+	return &SessionSigner{key: key, ttl: ttl}, nil
+}
+
+// TTL returns the configured session TTL.
+func (s *SessionSigner) TTL() time.Duration { return s.ttl }
+
+// Sign builds a session cookie value for the given identity.
+func (s *SessionSigner) Sign(subject, email string, now time.Time) (string, error) {
+	sess := Session{
+		Subject:   subject,
+		Email:     email,
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(s.ttl).Unix(),
+	}
+	payload, err := json.Marshal(sess)
+	if err != nil {
+		return "", err
+	}
+	encPayload := base64.RawURLEncoding.EncodeToString(payload)
+	mac := hmacSum(s.key, []byte(encPayload))
+	encSig := base64.RawURLEncoding.EncodeToString(mac)
+	return encPayload + "." + encSig, nil
+}
+
+// Verify decodes a cookie value, checks the signature, and returns the
+// session. Returns ErrSession* sentinels on every failure path.
+func (s *SessionSigner) Verify(cookieValue string, now time.Time) (*Session, error) {
+	if cookieValue == "" {
+		return nil, ErrSessionMissing
+	}
+	dot := strings.IndexByte(cookieValue, '.')
+	if dot < 0 || dot == len(cookieValue)-1 {
+		return nil, ErrSessionMalformed
+	}
+	encPayload := cookieValue[:dot]
+	encSig := cookieValue[dot+1:]
+
+	gotSig, err := base64.RawURLEncoding.DecodeString(encSig)
+	if err != nil {
+		return nil, ErrSessionMalformed
+	}
+	expectedSig := hmacSum(s.key, []byte(encPayload))
+	if subtle.ConstantTimeCompare(gotSig, expectedSig) != 1 {
+		return nil, ErrSessionBadSig
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(encPayload)
+	if err != nil {
+		return nil, ErrSessionMalformed
+	}
+	var sess Session
+	if err := json.Unmarshal(payload, &sess); err != nil {
+		return nil, ErrSessionMalformed
+	}
+	if now.Unix() >= sess.ExpiresAt {
+		return nil, ErrSessionExpired
+	}
+	return &sess, nil
+}
+
+// SignState produces a short-lived signed token for the OAuth state parameter.
+// Format: base64(random16).base64(hmac).base64(expiresUnix). 10-min lifetime.
+func (s *SessionSigner) SignState(now time.Time) (string, error) {
+	nonce := make([]byte, 16)
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
+	exp := now.Add(10 * time.Minute).Unix()
+	body := fmt.Sprintf("%s.%d", base64.RawURLEncoding.EncodeToString(nonce), exp)
+	mac := hmacSum(s.key, []byte(body))
+	return body + "." + base64.RawURLEncoding.EncodeToString(mac), nil
+}
+
+// VerifyState checks a state token's signature and expiry.
+func (s *SessionSigner) VerifyState(token string, now time.Time) error {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return ErrSessionMalformed
+	}
+	body := parts[0] + "." + parts[1]
+	gotSig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return ErrSessionMalformed
+	}
+	expectedSig := hmacSum(s.key, []byte(body))
+	if subtle.ConstantTimeCompare(gotSig, expectedSig) != 1 {
+		return ErrSessionBadSig
+	}
+	var exp int64
+	if _, err := fmt.Sscanf(parts[1], "%d", &exp); err != nil {
+		return ErrSessionMalformed
+	}
+	if now.Unix() >= exp {
+		return ErrSessionExpired
+	}
+	return nil
+}
+
+func hmacSum(key, msg []byte) []byte {
+	m := hmac.New(sha256.New, key)
+	m.Write(msg)
+	return m.Sum(nil)
+}
+
+// GenerateSessionSecret returns a base64-encoded 32-byte random string suitable
+// for the AuthConfig.SessionSecret field. Used by --gen-session-secret.
+func GenerateSessionSecret() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(b), nil
+}

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -1,0 +1,95 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newSigner(t *testing.T) *SessionSigner {
+	t.Helper()
+	// 64-char hex string — not valid base64, falls through to raw 64-byte key.
+	s, err := NewSessionSigner("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef!", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestSessionSigner_RoundTrip(t *testing.T) {
+	s := newSigner(t)
+	now := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	cookie, err := s.Sign("alice", "alice@example.com", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.Verify(cookie, now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if got.Subject != "alice" || got.Email != "alice@example.com" {
+		t.Fatalf("unexpected session: %+v", got)
+	}
+}
+
+func TestSessionSigner_TamperDetected(t *testing.T) {
+	s := newSigner(t)
+	cookie, _ := s.Sign("alice", "a@example.com", time.Now())
+	// Flip a byte in the payload portion.
+	tampered := "X" + cookie[1:]
+	if _, err := s.Verify(tampered, time.Now()); !errors.Is(err, ErrSessionBadSig) && !errors.Is(err, ErrSessionMalformed) {
+		t.Fatalf("expected sig/malformed error, got %v", err)
+	}
+}
+
+func TestSessionSigner_ExpirationEnforced(t *testing.T) {
+	s, err := NewSessionSigner("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef!", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	cookie, _ := s.Sign("a", "a@x.com", now)
+	if _, err := s.Verify(cookie, now.Add(48*time.Hour)); !errors.Is(err, ErrSessionExpired) {
+		t.Fatalf("expected ErrSessionExpired, got %v", err)
+	}
+}
+
+func TestSessionSigner_RejectsShortSecret(t *testing.T) {
+	if _, err := NewSessionSigner("short", 0); err == nil {
+		t.Fatal("expected error on short secret")
+	}
+}
+
+func TestSessionSigner_StateRoundTrip(t *testing.T) {
+	s := newSigner(t)
+	now := time.Now()
+	state, err := s.SignState(now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.VerifyState(state, now.Add(time.Minute)); err != nil {
+		t.Fatalf("VerifyState: %v", err)
+	}
+}
+
+func TestSessionSigner_StateExpires(t *testing.T) {
+	s := newSigner(t)
+	now := time.Now()
+	state, _ := s.SignState(now)
+	if err := s.VerifyState(state, now.Add(time.Hour)); !errors.Is(err, ErrSessionExpired) {
+		t.Fatalf("expected ErrSessionExpired, got %v", err)
+	}
+}
+
+func TestGenerateSessionSecret_DistinctAndLongEnough(t *testing.T) {
+	a, _ := GenerateSessionSecret()
+	b, _ := GenerateSessionSecret()
+	if a == b {
+		t.Fatal("two generated secrets collided")
+	}
+	// base64 of 32 bytes is 44 chars including padding.
+	if len(a) < 40 || strings.ContainsAny(a, " \t\n") {
+		t.Fatalf("unexpected secret format: %q", a)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,18 @@ var (
 	ErrMissingIMAPUsername = errors.New("IMAP_USERNAME is required: set via environment variable or config file")
 	// ErrMissingIMAPPassword is returned when IMAP password is not configured
 	ErrMissingIMAPPassword = errors.New("IMAP_PASSWORD is required: set via environment variable or config file")
+	// ErrAuthMissingClientID is returned when auth is enabled without a GitHub OAuth client ID
+	ErrAuthMissingClientID = errors.New("auth.client_id is required when auth.enabled (set AUTH_CLIENT_ID)")
+	// ErrAuthMissingClientSecret is returned when auth is enabled without a GitHub OAuth client secret
+	ErrAuthMissingClientSecret = errors.New("auth.client_secret is required when auth.enabled (set AUTH_CLIENT_SECRET)")
+	// ErrAuthMissingRedirectURL is returned when auth is enabled without a callback URL
+	ErrAuthMissingRedirectURL = errors.New("auth.redirect_url is required when auth.enabled (e.g., https://dmarc.example.com/auth/callback)")
+	// ErrAuthMissingSessionSecret is returned when auth is enabled without a session-signing secret
+	ErrAuthMissingSessionSecret = errors.New("auth.session_secret is required when auth.enabled (generate with --gen-session-secret)")
+	// ErrAuthSessionSecretTooShort is returned when the session secret is too short to safely sign cookies
+	ErrAuthSessionSecretTooShort = errors.New("auth.session_secret must decode to at least 32 bytes")
+	// ErrAuthAllowlistEmpty is returned when auth is enabled but no users/emails are allowed
+	ErrAuthAllowlistEmpty = errors.New("auth requires at least one entry in allowed_emails or allowed_users (otherwise no one can log in)")
 )
 
 // Config holds the application configuration
@@ -26,6 +38,22 @@ type Config struct {
 	IMAP        IMAPConfig     `json:"imap"`
 	Database    DatabaseConfig `json:"database"`
 	Server      ServerConfig   `json:"server"`
+	Auth        AuthConfig     `json:"auth" envPrefix:"AUTH_"`
+}
+
+// AuthConfig holds dashboard authentication configuration. When Enabled is
+// false (or the block is absent) the dashboard runs unauthenticated, matching
+// pre-auth behavior. When enabled, all /api/* and / routes require a valid
+// session cookie obtained via GitHub OAuth.
+type AuthConfig struct {
+	Enabled        bool     `json:"enabled" env:"ENABLED"`
+	ClientID       string   `json:"client_id" env:"CLIENT_ID"`
+	ClientSecret   string   `json:"client_secret" env:"CLIENT_SECRET"`
+	RedirectURL    string   `json:"redirect_url" env:"REDIRECT_URL"`
+	SessionSecret  string   `json:"session_secret" env:"SESSION_SECRET"`
+	AllowedEmails  []string `json:"allowed_emails" env:"ALLOWED_EMAILS" envSeparator:","`
+	AllowedUsers   []string `json:"allowed_users" env:"ALLOWED_USERS" envSeparator:","`
+	SessionTTLDays int      `json:"session_ttl_days" env:"SESSION_TTL_DAYS"`
 }
 
 // IMAPConfig holds IMAP server configuration
@@ -134,6 +162,35 @@ func (c *Config) Validate() error {
 	}
 	if c.IMAP.Password == "" {
 		return ErrMissingIMAPPassword
+	}
+	return nil
+}
+
+// ValidateAuth checks the auth configuration when it is enabled. Always called
+// before mounting auth handlers. Returns nil when auth is disabled.
+func (c *Config) ValidateAuth() error {
+	if !c.Auth.Enabled {
+		return nil
+	}
+	if c.Auth.ClientID == "" {
+		return ErrAuthMissingClientID
+	}
+	if c.Auth.ClientSecret == "" {
+		return ErrAuthMissingClientSecret
+	}
+	if c.Auth.RedirectURL == "" {
+		return ErrAuthMissingRedirectURL
+	}
+	if c.Auth.SessionSecret == "" {
+		return ErrAuthMissingSessionSecret
+	}
+	// Decoded length check happens when the secret is loaded by the auth
+	// package; here we just guard against obviously-short raw strings.
+	if len(c.Auth.SessionSecret) < 32 {
+		return ErrAuthSessionSecretTooShort
+	}
+	if len(c.Auth.AllowedEmails) == 0 && len(c.Auth.AllowedUsers) == 0 {
+		return ErrAuthAllowlistEmpty
 	}
 	return nil
 }

--- a/internal/config/config_auth_test.go
+++ b/internal/config/config_auth_test.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func validAuth() AuthConfig {
+	return AuthConfig{
+		Enabled:       true,
+		ClientID:      "abc",
+		ClientSecret:  "xyz",
+		RedirectURL:   "https://dmarc.example.com/auth/callback",
+		SessionSecret: strings.Repeat("a", 44),
+		AllowedEmails: []string{"seb@example.com"},
+	}
+}
+
+func TestValidateAuth_DisabledIsAlwaysOK(t *testing.T) {
+	cfg := &Config{Auth: AuthConfig{Enabled: false}}
+	if err := cfg.ValidateAuth(); err != nil {
+		t.Fatalf("disabled auth should not error: %v", err)
+	}
+}
+
+func TestValidateAuth_HappyPath(t *testing.T) {
+	cfg := &Config{Auth: validAuth()}
+	if err := cfg.ValidateAuth(); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestValidateAuth_MissingClientID(t *testing.T) {
+	a := validAuth()
+	a.ClientID = ""
+	cfg := &Config{Auth: a}
+	if err := cfg.ValidateAuth(); !errors.Is(err, ErrAuthMissingClientID) {
+		t.Fatalf("want ErrAuthMissingClientID, got %v", err)
+	}
+}
+
+func TestValidateAuth_MissingSecret(t *testing.T) {
+	a := validAuth()
+	a.ClientSecret = ""
+	cfg := &Config{Auth: a}
+	if err := cfg.ValidateAuth(); !errors.Is(err, ErrAuthMissingClientSecret) {
+		t.Fatalf("want ErrAuthMissingClientSecret, got %v", err)
+	}
+}
+
+func TestValidateAuth_ShortSessionSecret(t *testing.T) {
+	a := validAuth()
+	a.SessionSecret = "tooshort"
+	cfg := &Config{Auth: a}
+	if err := cfg.ValidateAuth(); !errors.Is(err, ErrAuthSessionSecretTooShort) {
+		t.Fatalf("want ErrAuthSessionSecretTooShort, got %v", err)
+	}
+}
+
+func TestValidateAuth_EmptyAllowlistRejected(t *testing.T) {
+	a := validAuth()
+	a.AllowedEmails = nil
+	a.AllowedUsers = nil
+	cfg := &Config{Auth: a}
+	if err := cfg.ValidateAuth(); !errors.Is(err, ErrAuthAllowlistEmpty) {
+		t.Fatalf("want ErrAuthAllowlistEmpty, got %v", err)
+	}
+}
+
+func TestValidateAuth_AllowsUserOnlyAllowlist(t *testing.T) {
+	a := validAuth()
+	a.AllowedEmails = nil
+	a.AllowedUsers = []string{"sebykrueger"}
+	cfg := &Config{Auth: a}
+	if err := cfg.ValidateAuth(); err != nil {
+		t.Fatalf("user-only allowlist should validate, got %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/meysam81/parse-dmarc/internal/api"
+	"github.com/meysam81/parse-dmarc/internal/auth"
 	"github.com/meysam81/parse-dmarc/internal/config"
 	"github.com/meysam81/parse-dmarc/internal/imap"
 	"github.com/meysam81/parse-dmarc/internal/logger"
@@ -139,6 +140,11 @@ func main() {
 				Usage:   "Skip TLS certificate verification (development only)",
 				Sources: cli.EnvVars("PARSE_DMARC_MCP_OAUTH_INSECURE"),
 			},
+			&cli.BoolFlag{
+				Name:    "gen-session-secret",
+				Usage:   "Generate a base64-encoded 32-byte session secret for auth.session_secret and exit",
+				Sources: cli.EnvVars("PARSE_DMARC_GEN_SESSION_SECRET"),
+			},
 		},
 		Action: run,
 		Commands: []*cli.Command{
@@ -187,6 +193,15 @@ func run(ctx context.Context, cmd *cli.Command) error {
 			return fmt.Errorf("failed to generate config: %w", err)
 		}
 		log.Info().Str("path", configPath).Msg("sample configuration written")
+		return nil
+	}
+
+	if cmd.Bool("gen-session-secret") {
+		secret, err := auth.GenerateSessionSecret()
+		if err != nil {
+			return fmt.Errorf("generate session secret: %w", err)
+		}
+		fmt.Println(secret)
 		return nil
 	}
 
@@ -267,6 +282,25 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	defer stop()
 
 	server := api.NewServer(store, cfg.Server.Host, cfg.Server.Port, m, log)
+
+	if cfg.Auth.Enabled {
+		if err := cfg.ValidateAuth(); err != nil {
+			return fmt.Errorf("auth configuration error: %w", err)
+		}
+		signer, err := auth.NewSessionSigner(cfg.Auth.SessionSecret, cfg.Auth.SessionTTLDays)
+		if err != nil {
+			return fmt.Errorf("auth signer: %w", err)
+		}
+		github := auth.NewGitHubClient(cfg.Auth.ClientID, cfg.Auth.ClientSecret, cfg.Auth.RedirectURL, nil)
+		allowlist := auth.NewAllowlist(cfg.Auth.AllowedEmails, cfg.Auth.AllowedUsers)
+		handlers := auth.NewHandlers(github, signer, allowlist, cfg.Auth.RedirectURL, log)
+		server.WithAuth(handlers, signer)
+		log.Info().
+			Int("allowed_emails", len(cfg.Auth.AllowedEmails)).
+			Int("allowed_users", len(cfg.Auth.AllowedUsers)).
+			Msg("dashboard authentication enabled (github)")
+	}
+
 	serverErrChan := make(chan error, 1)
 	go func() {
 		serverErrChan <- server.Start(ctx)

--- a/src/components/settings/SettingsModal.vue
+++ b/src/components/settings/SettingsModal.vue
@@ -1,6 +1,7 @@
 <script setup>
-import { computed, ref, watch } from "vue";
+import { computed, ref, watch, onMounted } from "vue";
 import { useThemeStore, useSettingsStore } from "@/stores";
+import { getCurrentUser } from "@/lib/api.js";
 
 const props = defineProps({
   isOpen: {
@@ -18,13 +19,39 @@ const settingsStore = useSettingsStore();
 const editingEndpoint = ref(settingsStore.apiEndpoint);
 const validationError = ref("");
 
+// Auth state
+const currentUser = ref(null);
+const loadingUser = ref(false);
+
+// Fetch current user on mount
+onMounted(async () => {
+  loadingUser.value = true;
+  try {
+    currentUser.value = await getCurrentUser();
+  } catch (error) {
+    // Silently fail - auth might be disabled
+    currentUser.value = null;
+  } finally {
+    loadingUser.value = false;
+  }
+});
+
 // Sync editing endpoint when modal opens or store changes
 watch(
   () => props.isOpen,
-  (open) => {
+  async (open) => {
     if (open) {
       editingEndpoint.value = settingsStore.apiEndpoint;
       validationError.value = "";
+      // Fetch user info when modal opens (in case user logged in after component mounted)
+      try {
+        const user = await getCurrentUser();
+        console.log('[SettingsModal] Fetched user:', user);
+        currentUser.value = user;
+      } catch (error) {
+        console.error('[SettingsModal] Failed to fetch user:', error);
+        currentUser.value = null;
+      }
     }
   },
 );
@@ -75,6 +102,10 @@ function handleBackdropClick(event) {
   if (event.target === event.currentTarget) {
     closeModal();
   }
+}
+
+function handleLogout() {
+  window.location.href = currentUser.value.logout_url;
 }
 
 // Theme helpers
@@ -136,6 +167,55 @@ const themeOptions = [
           </div>
 
           <div class="modal-body">
+            <!-- User Info Section (only shown when authenticated) -->
+            <section v-if="currentUser" class="settings-section user-section">
+              <h3 class="section-label">Account</h3>
+              <div class="user-info">
+                <div class="user-details">
+                  <div class="user-login">
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                      <circle cx="12" cy="7" r="4" />
+                    </svg>
+                    <span class="user-name">@{{ currentUser.login }}</span>
+                  </div>
+                  <div v-if="currentUser.email" class="user-email">
+                    {{ currentUser.email }}
+                  </div>
+                </div>
+                <a
+                  :href="currentUser.logout_url"
+                  class="btn btn-logout"
+                  @click.prevent="handleLogout"
+                >
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                    <polyline points="16 17 21 12 16 7" />
+                    <line x1="21" y1="12" x2="9" y2="12" />
+                  </svg>
+                  Logout
+                </a>
+              </div>
+            </section>
+
             <!-- Theme Section -->
             <section class="settings-section">
               <h3 class="section-label">Theme</h3>
@@ -340,6 +420,77 @@ const themeOptions = [
   align-items: center;
   justify-content: center;
   z-index: 100;
+
+/* User Section */
+.user-section {
+  padding-bottom: 20px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.user-info {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 16px;
+  background: var(--bg-app);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-card);
+}
+
+.user-details {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.user-login {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: var(--text-main);
+  font-size: 0.875rem;
+}
+
+.user-login svg {
+  color: var(--text-muted);
+}
+
+.user-name {
+  font-family: var(--font-mono);
+}
+
+.user-email {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  padding-left: 24px;
+}
+
+.btn-logout {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: all 0.2s;
+  cursor: pointer;
+}
+
+.btn-logout:hover {
+  border-color: var(--c-danger);
+  color: var(--c-danger);
+  background: rgba(239, 68, 68, 0.05);
+}
+
+
   padding: 16px;
 }
 

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -77,6 +77,22 @@ export const getReports = ({ limit = 20, offset = 0 } = {}) =>
   createApiClient().get("reports", { searchParams: { limit, offset } }).json();
 
 /**
+ * Get current authenticated user information
+ * Returns null if authentication is disabled or user is not logged in
+ */
+export const getCurrentUser = async () => {
+  try {
+    return await createApiClient().get("auth/me").json();
+  } catch (error) {
+    // Return null if auth is disabled (401) or any other error
+    if (error.response?.status === 401) {
+      return null;
+    }
+    throw error;
+  }
+};
+
+/**
  * Get a single report by ID
  * @param {string|number} id - Report ID
  */


### PR DESCRIPTION
## Summary

Adds opt-in GitHub OAuth login for the dashboard. When the `auth` block is absent or `auth.enabled=false`, the dashboard runs unauthenticated as today (no breaking change). When enabled, `/api/*` and `/` require a signed session cookie obtained via GitHub OAuth; `/metrics` stays open so Prometheus scrapers keep working.

- New `internal/auth` package: HMAC-SHA256 signed cookie sessions (no server-side store), GitHub OAuth client with `/user` + `/user/emails` calls to extract login + verified primary email, allowlist matching (case-insensitive emails OR usernames), and middleware that returns 303→`/auth/login` for browsers and 401 JSON for `/api/*` callers.
- New `/auth/login`, `/auth/callback`, `/auth/logged-out`, `/auth/logout` handlers. Logout lands on a dedicated static page rather than redirecting back through GitHub — otherwise the user gets silently re-authenticated and Logout looks broken.
- New `/api/auth/me` endpoint returns `{login, email, logout_url}` for the current session, used by the SPA.
- Frontend: an Account section in the existing Settings modal showing the GitHub @username and email, plus a Logout button. Hidden when auth is disabled.
- New `--gen-session-secret` CLI flag prints a 32-byte base64 secret.

## Why GitHub OAuth (not OIDC)?

GitHub doesn't implement OIDC (no discovery doc, no ID tokens, separate `/user/emails` API call to get the verified email). Treating it as a first-class provider rather than forcing it through a generic OIDC abstraction kept the code simpler and removes the need for users to stand up a federating IDP just to log in with their GitHub account. A future PR can add a generic OIDC provider alongside if there's demand for Google/Microsoft/Authentik/Keycloak.

## Config shape

```json
"auth": {
  "enabled": true,
  "client_id": "Iv1.xxxx",
  "client_secret": "xxxx",
  "redirect_url": "https://dmarc.example.com/auth/callback",
  "session_secret": "<--gen-session-secret>",
  "allowed_users": ["sebykrueger"],
  "allowed_emails": ["seb@example.com"],
  "session_ttl_days": 7
}
```

`ValidateAuth()` refuses to start when `auth.enabled=true` and the allowlist is empty (otherwise nobody could log in). All fields also available as env vars (`AUTH_ENABLED`, `AUTH_CLIENT_ID`, `AUTH_ALLOWED_USERS=a,b,c`, etc.) for Docker/k8s secrets.

## Security notes

- Sessions are stateless HMAC-signed cookies (`HttpOnly; SameSite=Lax`; `Secure` flag inferred from `https://` redirect URL). No server-side session store.
- OAuth `state` is a separate signed token, validated against a short-lived state cookie scoped to `/auth/callback` for CSRF protection on the callback.
- `/metrics` is intentionally **not** auth-gated so existing Prometheus scrapers don't break.
- Removing someone from the allowlist doesn't kill their existing session (cookie keeps working until `session_ttl_days`). To force-evict immediately, rotate `auth.session_secret`. Documented as a known gotcha in the README.

## Test plan

- [x] `go test ./...` — session sign/verify round-trip + tamper detection + expiry, state token round-trip + expiry, secret-too-short rejection, allowlist case-insensitive matching for emails and logins, empty allowlist denies all, middleware decision matrix (no cookie → 303 browser / 401 api, garbage cookie → same, valid cookie → pass through with populated context for `/api/auth/me`), full config validation matrix.
- [x] `go vet ./...` clean.
- [x] `go build ./...` clean for both pure-Go and CGO modes.
- [x] Manual end-to-end against a real GitHub OAuth App on `http://localhost:8080`: login flow, allowlist denial, logout flow with the dedicated landing page (verified you don't get silently re-authenticated through GitHub).
- [x] Verified `/metrics` stays open with auth enabled.
- [x] Verified existing deployments without an `auth` block continue to run unauthenticated (`AuthConfig{Enabled: false}` is the zero value).