### PR TITLE
fix(docker): make /data writable under non-root runtimes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ ENV PARSE_DMARC_CONFIG=/app/config.json \
 
 COPY --from=backend-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=backend-builder /app/parse-dmarc /usr/local/bin/parse-dmarc
-COPY --from=backend-builder /data /data
+COPY --from=backend-builder --chmod=0777 /data /data
 COPY --from=backend-builder /tmp /tmp
 
 EXPOSE 8080


### PR DESCRIPTION
## What

Fixes #138.

`/data` is baked into the final `scratch` image as `root:root 0755`, which is writable only when the container runs as **root** (the image default). Under any non-root runtime — Kubernetes `securityContext: runAsNonRoot`, OpenShift's arbitrary UID, `docker run --user`, or rootless Podman — the process can't create `/data/parse-dmarc.db`, and startup fails with:

```
failed to initialize storage: initialize database schema: exec schema: unable to open database file (14)
```

SQLite error 14 is `SQLITE_CANTOPEN` — a permissions problem, not the "out of memory" the message elsewhere suggests. (The original report shows the same code rendered as `... : out of memory (14)` on an older SQLite build.)

## Why the earlier fix didn't cover it

e8d6497 ("create DB parent dirs") pre-creates `/data` in the builder and copies it into the final stage. But `mkdir` runs as root there, so `/data` still lands as `root:0755` — the directory now exists, but it's still not writable by a non-root user. That's why it's still reported broken on 1.5.3.

The missing piece isn't creating the directory; it's making it writable regardless of the runtime UID.

## The change

```diff
-COPY --from=backend-builder /data /data
+COPY --from=backend-builder --chmod=0777 /data /data
```

One line. `--chmod` is already available since the Dockerfile uses `# syntax=docker/dockerfile:1` (BuildKit). Root deployments are unaffected; non-root runtimes now work.

## Reproduction

Config validation runs before storage init, so a dummy IMAP config is needed to reach the DB code:

```
docker build -t dg .

# on main, NON-root on a fresh volume -> fails at storage init:
docker volume rm t 2>/dev/null
docker run --rm --user 1000:1000 -e IMAP_HOST=imap.invalid -e IMAP_USERNAME=x -e IMAP_PASSWORD=x -v t:/data dg
#   failed to initialize storage: ... unable to open database file (14)   (SQLITE_CANTOPEN)

# on main, ROOT -> storage initializes, server starts (then stops on the fake IMAP host):
docker volume rm t 2>/dev/null
docker run --rm -e IMAP_HOST=imap.invalid -e IMAP_USERNAME=x -e IMAP_PASSWORD=x -v t:/data dg
#   starting server addr=:8080
```

With this PR, the NON-root run also starts the server. Confirmed on the built image: `/data` goes from `drwxr-xr-x` (root:root 0755) to `drwxrwxrwx` (0777), writable by any UID.

## Alternative considered

A stronger option is to make the image non-root by default (`USER 65532` + `--chown` on `/data` and `/tmp`), which also hardens the image. I kept this PR to the minimal, non-breaking change, since running as non-root by default alters runtime behavior and existing root-populated volumes would need a one-time chown on upgrade. Happy to follow up with that if you'd prefer it.
